### PR TITLE
Mp calls

### DIFF
--- a/multipass/mp-calls
+++ b/multipass/mp-calls
@@ -1,0 +1,33 @@
+# Helper functions to extend the usability, scripting and automation
+# possibilities of the Multipass tool.
+
+#######################################
+# Get the IP address of a multipass instance.
+# Arguments:
+#   Name of the VM instance
+# Outputs:
+#   Writes IP address to stdout
+#######################################
+mp-info-ip() {
+  local line=($(multipass info $1 | grep IPv4))
+  echo ${line[1]}
+}
+
+#######################################
+# Appends the public SSH key of the host to the authorized keys
+# of the Multipass instance.
+# Arguments:
+#   Path to the public key on the host
+#   Name of the VM instance
+#######################################
+mp-copy-ssh() {
+  local key=$(cat $1)
+  local instance=$2
+  local authorized=/home/ubuntu/.ssh/authorized_keys
+  multipass exec $instance -- bash -c "
+    if ! echo $key | grep -f $authorized > /dev/null
+    then
+      echo $key >> $authorized
+    fi
+  " $key $authorized
+}

--- a/multipass/mp-calls
+++ b/multipass/mp-calls
@@ -4,7 +4,7 @@
 #######################################
 # Get the IP address of a multipass instance.
 # Arguments:
-#   Name of the VM instance
+#   Multipass instance name
 # Outputs:
 #   Writes IP address to stdout
 #######################################
@@ -14,20 +14,43 @@ mp-info-ip() {
 }
 
 #######################################
-# Appends the public SSH key of the host to the authorized keys
+# Append the public SSH key of the host to the authorized keys
 # of the Multipass instance.
 # Arguments:
 #   Path to the public key on the host
-#   Name of the VM instance
+#   Multipass instance name
 #######################################
 mp-copy-ssh() {
   local key=$(cat $1)
-  local instance=$2
+  local name=$2
   local authorized=/home/ubuntu/.ssh/authorized_keys
-  multipass exec $instance -- bash -c "
+  multipass exec $name -- bash -c "
     if ! echo $key | grep -f $authorized > /dev/null
     then
       echo $key >> $authorized
     fi
   " $key $authorized
+}
+
+#######################################
+# Set a static IP address to a Multipass instance.
+# Arguments:
+#   Multipass instance name
+#   IP address
+#######################################
+mp-static-ip() {
+  local name=$1
+  local ip=$2
+  multipass exec $name -- bash -c "
+    # Copies cloud-init configuration file,
+    # removes comments and adds static IP
+    # to the new configuraton file
+    # and then applies the new netplan
+    # inside the multipass instance.
+    cat /etc/netplan/50-cloud-init.yaml \
+      | grep -v '#' \
+      | sed 's/^\( *\)dhcp4: true$/&\n\1addresses:\n\1- ${ip}\/24/' \
+      | sudo tee /etc/netplan/99-static.yaml > /dev/null
+    sudo netplan apply
+  " $ip
 }

--- a/multipass/mp-launch
+++ b/multipass/mp-launch
@@ -57,7 +57,7 @@ QUIET=
 # Level of logging verbosity (for the multipass launch command)
 VERBOSE=0
 
-# Path to a user-data cloud-init configuration (multipass launch --cloud-init)
+# User-data cloud-init configuration (multipass launch --cloud-init)
 INIT=
 
 # Network interface spec to the instance (multipass launch --network)
@@ -69,7 +69,7 @@ BRIDGED=
 # <local-path>:<instance-path> mount (multipass launch --mount)
 MOUNT=
 
-# Maximum time, in seconds, to wait (for multipass lauch command --timeout)
+# Seconds to wait VM lauch (for multipass lauch command --timeout)
 TIMEOUT=
 
 # -T option with time in seconds to wait for mp-ssh to connect to VM
@@ -261,8 +261,8 @@ ssh_command() {
 # Handling command line arguments
 #######################################
 if ! OPTS="$(getopt \
-  --longoptions help,cpus:,disk:,memory:,name:,filename:,type:,keygen,ip:,quiet,\
-verbose,cloud-init:,network:,bridged,mount:,timeout: \
+  --longoptions help,cpus:,disk:,memory:,name:,filename:,type:,keygen,\
+ip:,quiet,verbose,cloud-init:,network:,bridged,mount:,timeout: \
   --options hc:d:m:n:f:t:ki:qvT: \
   --name "$(basename "$0")" \
   -- "$@"

--- a/multipass/mp-ssh
+++ b/multipass/mp-ssh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-set -e
-
+#
 # Script to extend the usability, scripting and automation possiblities
 # of the Multipass tool.
 #
@@ -16,6 +15,16 @@ set -e
 # a static IP.
 #
 # Check the usage() function below for more usage options
+
+#######################################
+# Shell options
+#######################################
+set -e
+
+#######################################
+# Includes
+#######################################
+. mp-calls
 
 #######################################
 # DEFAULT VALUES
@@ -182,18 +191,6 @@ specify_key()  {
 }
 
 #######################################
-# Get the IP address of the multipass instance.
-# Arguments:
-#   None
-# Outputs:
-#   Writes IP address to stdout
-#######################################
-instance_ip() {
-  local line=($(multipass info $1 | grep IPv4))
-  echo ${line[1]}
-}
-
-#######################################
 # EXECUTION
 #######################################
 
@@ -294,20 +291,16 @@ if [ ! -f $KEY.pub ]; then
   exit_error
 fi
 
-# Copying the public key to the multipass instance.
-# If multipass instance name is wrong or missing,
-# exec command fails and displays an error message.
-if ! cat $KEY.pub | multipass exec $NAME -- \
-  tee -a /home/ubuntu/.ssh/authorized_keys \
-  > /dev/null
-then
-   exit_error
+# Copy the public SSH key to the multipass instance.
+# Multipass displays an error message if the instance name is wrong.
+if ! mp-copy-ssh $KEY.pub $NAME; then
+  exit_error
 fi
 
 # Static IP is set for VM instance if --ip option is used
 # Otherwise a dynamic IP given by Multipass is used.
 if [ -z "$IP" ]; then
-  IP=$(instance_ip $NAME)
+  IP=$(mp-info-ip $NAME)
 else
   # Copies cloud-init configuration file,
   # removes comments and adds static IP
@@ -346,7 +339,9 @@ echo
 echo "Open a shell prompt on the $NAME:"
 echo "$ multipass shell $NAME"
 echo "OR"
-if [ "$(dirname $KEY)" == ~/.ssh ] && [ "$(basename $KEY)" == id_"$TYPE" ]; then
+if [ "$(dirname $KEY)" == ~/.ssh ] && \
+   [ "$(basename $KEY)" == id_"$TYPE" ]
+then
   echo "$ ssh ubuntu@$IP"
 else
   echo "$ ssh -i $KEY ubuntu@$IP"

--- a/multipass/mp-ssh
+++ b/multipass/mp-ssh
@@ -302,18 +302,7 @@ fi
 if [ -z "$IP" ]; then
   IP=$(mp-info-ip $NAME)
 else
-  # Copies cloud-init configuration file,
-  # removes comments and adds static IP
-  # to the new configuraton file
-  # and then applies the new netplan
-  # inside the multipass instance.
-  multipass exec $NAME -- bash -c "
-    cat /etc/netplan/50-cloud-init.yaml \
-      | grep -v '#' \
-      | sed 's/^\( *\)dhcp4: true$/&\n\1addresses:\n\1- ${IP}\/24/' \
-      | sudo tee /etc/netplan/99-static.yaml > /dev/null
-    sudo netplan apply
-  " $IP
+  mp-static-ip $NAME $IP
   # Adds a new route on host if not available
   sudo ip route replace $ROUTE/24 dev mpqemubr0
 fi


### PR DESCRIPTION
mp-calls: reusable Multipass functions moved to separate file

mp-ssh-copy
- copies public SSH key to the authorzed keys file of VM instance

mp-info-ip
- gets the curent dynamic IP address of a Multipass instance

mp-static-ip
- sets a static IP address to a Multipass instance

minor cosmetic changes
- shortening longer script lines

Signed-off-by: Marko Kaapu <marko.kaapu@unikie.com>