### PR TITLE
mp-ssh: correct note if a new SSH key was generated or not

### DIFF
--- a/multipass/mp-ssh
+++ b/multipass/mp-ssh
@@ -275,13 +275,17 @@ fi
 specify_key "$KEY" "$TYPE"
 echo SSH key file: $KEY
 echo Key type: $TYPE
-echo New key generation: $KEYGEN
 
 # SSH key pair generation with --keygen option
 if $KEYGEN; then
   if [ ! -f $KEY ]; then
     ssh-keygen -q -t $TYPE -f $KEY -N ''
+    echo New SSH key was generated.
+  else
+    echo No new SSH keys were generated.
   fi
+else
+  echo No new SSH keys were generated.
 fi
 
 # If public key not found


### PR DESCRIPTION
- with --keygen option a new key is generated only if specified key does not exist already
- fixes note printed to stdout when -k option was used but no new keys were generated because of already existing key

Signed-off-by: Marko Kaapu <marko.kaapu@unikie.com>