### PR TITLE
launch-vm-agent: Add SSH tunnel properly with eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ The *jenkins* directory contains bash scripts to help to setup [Jenkins](https:/
 - Installs Java JDK 17 to the VM.
 - Enables logging into the VM using SSH tunnel through a local port of the host.
 - [Documentation](jenkins/vm-agent)
+
+## Tools to enable remote login with SSH
+The **ssh** directory contains bash scripts to enable automated remote login and command-line execution of SSH application.
+
+### make-ssh-tunnel
+- Creates a persistent SSH tunnel between servers as systemd service.
+- [Documentation](ssh/make-ssh-tunnel)
+
+### rm-ssh-tunnel
+- Removes a SSH tunnel and systemd service created by the [make-ssh-tunnel](#make-ssh-tunnel)
+- [Documentation](ssh/rm-ssh-tunnel)

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ The *jenkins* directory contains bash scripts to help to setup [Jenkins](https:/
 - Creates a Ubuntu LTS VM and prepare it as a Jenkis agent.
 - Installs Java JDK 17 to the VM.
 - Enables logging into the VM using SSH tunnel through a local port of the host.
-- [Documentation](jenkins/vm-agent)
+- [Documentation](jenkins/vm-agent#launch-vm-agent)
 
 ## Tools to enable remote login with SSH
 The **ssh** directory contains bash scripts to enable automated remote login and command-line execution of SSH application.
 
 ### make-ssh-tunnel
 - Creates a persistent SSH tunnel between servers as systemd service.
-- [Documentation](ssh/make-ssh-tunnel)
+- [Documentation](ssh#make-ssh-tunnel)
 
 ### rm-ssh-tunnel
 - Removes a SSH tunnel and systemd service created by the [make-ssh-tunnel](#make-ssh-tunnel)
-- [Documentation](ssh/rm-ssh-tunnel)
+- [Documentation](ssh#rm-ssh-tunnel)

--- a/jenkins/vm-agent/README.md
+++ b/jenkins/vm-agent/README.md
@@ -2,7 +2,7 @@
 Tool to create a Ubuntu LTS VM and prepare it as a [Jenkins](https://www.jenkins.io/) agent.
 
 ## What it does
-* **launc-vm-agent** utility installs [Multipass](https://multipass.run/) tool if it is not installed.
+* **launch-vm-agent** utility installs [Multipass](https://multipass.run/) tool if it is not installed.
 * It generates a new SSH key if no existing key (ed25519) is found from user's home directory (*.ssh/id_ed25519*).
 * It creates a Ubuntu LTS virtual machine with the settings specified by given commandline options.
 * It stores the public SSH key of the host to the authorized_keys file on the VM to allow passwordless login with public key authentication.
@@ -25,7 +25,7 @@ With this example:
 * New Ubuntu LTS VM will be launched with the name 'vm-agent'.
 * 2 CPUs, 2G of memory and 10G of disk space will be allocated to the launched VM.
 * VM will have static IP: 10.100.123.101
-* The host (where you execute the above command) should have an IP address: 10.101.123.111
+* The host (where you execute the above command) should have an IP address: 10.101.123.111 (binding the local port to that address)
 * You should be able to log in to the VM through the local port of the host: 3333
 
 You can log directly in to the VM launched in the above example using SSH:

--- a/jenkins/vm-agent/launch-vm-agent
+++ b/jenkins/vm-agent/launch-vm-agent
@@ -9,8 +9,8 @@ NAME=primary
 CPUS=1
 DISK=5G
 MEM=1G
-VM_IP=10.10.20.10
-HOST_IP=10.10.10.10
+VM_IP=10.10.10.10
+HOST_IP=0.0.0.0
 PORT=2222
 
 #######################################
@@ -33,18 +33,21 @@ usage() {
   echo
   echo "Options:"
   echo "  -h, --help            Displays help on commandline options"
-  echo "  -n, --name <name>	VM instance name"
-  echo "  -c, --cpus <cpus>	Number of CVPUs to allocate"
-  echo "			Default: 1"
-  echo "  -d, --disk <disk>	Disk space to allocate"
-  echo "			Default: 5G"
-  echo "  -m, --mem <mem>	Amount of memeory to allocate"
-  echo "			Default: 1G"
-  echo "  -v, --vm-ip <ip>	IP address of VM instance"
-  echo "  -i, --host-ip <ip>	Local IP of the host"
-  echo "  -p, --port <port>	Local port forwarded to the VM instance"
-  echo "			to create a SSH tunnel"
-  echo "			Default: 2222"
+  echo "  -n, --name <name>     VM instance name"
+  echo "  -c, --cpus <cpus>     Number of CPUs to allocate"
+  echo "                        Default: 1"
+  echo "  -d, --disk <disk>     Disk space to allocate"
+  echo "                        Default: 5G"
+  echo "  -m, --mem <mem>       Amount of memeory to allocate"
+  echo "                        Default: 1G"
+  echo "  -v, --vm-ip <ip>      Static IP adress for the VM"
+  echo "                        Default: 10.10.10.10"
+  echo "  -i, --host-ip <ip>    Bind address of the local host"
+  echo "                        Default: 0.0.0.0 (makes local port"
+  echo "                        available on all interfaces)"
+  echo "  -p, --port <port>     Local port forwarded to the VM instance"
+  echo "                        to create a SSH tunnel"
+  echo "                        Default: 2222"
 }
 
 #######################################
@@ -75,6 +78,13 @@ while true; do
     *) echo "DEBUG: No implementation for the option $1" ; exit 1 ;;
   esac
 done
+ARGS=("$@")
+ARGCOUNT=${#ARGS[@]}
+if [ "${#ARGS[@]}" -ne "0" ]; then
+  echo "Unexpected arguments supplied."
+  usage
+  exit 1
+fi
 
 echo
 echo "Installing Multipass tool.."

--- a/jenkins/vm-agent/launch-vm-agent
+++ b/jenkins/vm-agent/launch-vm-agent
@@ -108,14 +108,7 @@ multipass exec $NAME -- bash -c "
 
 echo
 echo "Creating SSH tunnel through local port: $PORT to the VM instance."
-SSH_TUNNEL=( ssh -f -N ubuntu@${VM_IP} -L ${HOST_IP}:${PORT}:${VM_IP}:22 )
-"${SSH_TUNNEL[@]}"
-
-if ! crontab -l 2>/dev/null | grep '@reboot "${SSH_TUNNEL[@]}"' >/dev/null; then
-  echo
-  echo "Adding SSH tunneling to crontab so it is available on startup."
-  crontab -l 2>/dev/null | { cat; echo "@reboot ${SSH_TUNNEL[@]}"; } | crontab -
-fi
+make-ssh-tunnel -i $HOST_IP -s $VM_IP -p $PORT $NAME
 
 echo
 echo "Append a public key to the authorized_keys on the VM instance"

--- a/jenkins/vm-agent/launch-vm-agent
+++ b/jenkins/vm-agent/launch-vm-agent
@@ -9,8 +9,8 @@ NAME=primary
 CPUS=1
 DISK=5G
 MEM=1G
-VM_IP=10.10.20.11
-HOST_IP=10.10.10.11
+VM_IP=10.10.20.10
+HOST_IP=10.10.10.10
 PORT=2222
 
 #######################################
@@ -76,6 +76,7 @@ while true; do
   esac
 done
 
+echo
 echo "Installing Multipass tool.."
 sudo snap install multipass
 
@@ -108,9 +109,9 @@ multipass exec $NAME -- bash -c "
 echo
 echo "Creating SSH tunnel through local port: $PORT to the VM instance."
 SSH_TUNNEL="ssh -f -N ubuntu@${VM_IP} -L ${HOST_IP}:${PORT}:${VM_IP}:22"
-$(echo $SSH_TUNNEL)
+eval $SSH_TUNNEL
 
-if ! crontab -l | grep "@reboot $SSH_TUNNEL" >/dev/null; then
+if ! crontab -l 2>/dev/null | grep "@reboot $SSH_TUNNEL" >/dev/null; then
   echo
   echo "Adding SSH tunneling to crontab so it is available on startup."
   crontab -l 2>/dev/null | { cat; echo "@reboot $SSH_TUNNEL"; } | crontab -

--- a/jenkins/vm-agent/launch-vm-agent
+++ b/jenkins/vm-agent/launch-vm-agent
@@ -108,13 +108,13 @@ multipass exec $NAME -- bash -c "
 
 echo
 echo "Creating SSH tunnel through local port: $PORT to the VM instance."
-SSH_TUNNEL="ssh -f -N ubuntu@${VM_IP} -L ${HOST_IP}:${PORT}:${VM_IP}:22"
-eval $SSH_TUNNEL
+SSH_TUNNEL=( ssh -f -N ubuntu@${VM_IP} -L ${HOST_IP}:${PORT}:${VM_IP}:22 )
+"${SSH_TUNNEL[@]}"
 
-if ! crontab -l 2>/dev/null | grep "@reboot $SSH_TUNNEL" >/dev/null; then
+if ! crontab -l 2>/dev/null | grep '@reboot "${SSH_TUNNEL[@]}"' >/dev/null; then
   echo
   echo "Adding SSH tunneling to crontab so it is available on startup."
-  crontab -l 2>/dev/null | { cat; echo "@reboot $SSH_TUNNEL"; } | crontab -
+  crontab -l 2>/dev/null | { cat; echo "@reboot ${SSH_TUNNEL[@]}"; } | crontab -
 fi
 
 echo

--- a/jenkins/vm-agent/launch-vm-agent
+++ b/jenkins/vm-agent/launch-vm-agent
@@ -108,7 +108,7 @@ multipass exec $NAME -- bash -c "
 
 echo
 echo "Creating SSH tunnel through local port: $PORT to the VM instance."
-make-ssh-tunnel -i $HOST_IP -s $VM_IP -p $PORT $NAME
+make-ssh-tunnel -b $HOST_IP -i $VM_IP -p $PORT $NAME
 
 echo
 echo "Append a public key to the authorized_keys on the VM instance"

--- a/setup
+++ b/setup
@@ -84,5 +84,7 @@ sudo cp -v $INTERACTIVE \
   $UTILITY_DIR/multipass/mp-launch \
   $UTILITY_DIR/multipass/mp-launch-usage \
   $UTILITY_DIR/jenkins/vm-agent/launch-vm-agent \
+  $UTILITY_DIR/ssh/make-ssh-tunnel \
+  $UTILITY_DIR/ssh/ssh-tunnel-persistent.service \
   $DESTINATION.
 echo "vm-utility installed."

--- a/setup
+++ b/setup
@@ -85,6 +85,7 @@ sudo cp -v $INTERACTIVE \
   $UTILITY_DIR/multipass/mp-launch-usage \
   $UTILITY_DIR/jenkins/vm-agent/launch-vm-agent \
   $UTILITY_DIR/ssh/make-ssh-tunnel \
+  $UTILITY_DIR/ssh/rm-ssh-tunnel \
   $UTILITY_DIR/ssh/ssh-tunnel-persistent.service \
   $DESTINATION.
 echo "vm-utility installed."

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -1,0 +1,49 @@
+# SSH Tools
+
+These are Bash scripts to enable automated remote login and command-line execution of SSH applications.
+
+## Installation
+
+Use the simple setup script from the root of the repository to copy tools to */usr/bin/local* where they are available for all users and other tools:
+```
+git clone https://github.com/mkaapu/vm-utility.git
+sudo vm-utility/setup
+```
+Or you can just clone the project and add the *ssh* directory to your PATH.
+
+## make-ssh-tunnel
+Creates a persistent SSH tunnel between servers with systemd.
+
+### What it does
+* **make-ssh-tunnel** creates a systemd service which enables persistent SSH tunnel from a local port to a port on an external server.
+* Uses the *ssh-tunnel-persistent.service* template file for writing the systemd unit file to *~/.config/systemd/user/*.
+* Starts the service and enables the service to be autostarted.
+* Enables the user process for the service to run without any open sessions on the local host.
+* When connection is dropped, then systemd will wait 3 seconds and continuously attempt to reconnect.
+
+### Full usage and options
+```
+make-ssh-tunnel -h
+```
+
+### Example
+```
+make-ssh-tunnel --ip 10.10.10.10 --server 11.11.11.11 --user ubuntu --port 3333 --to-port 333 vmserver
+```
+* Creates a persistent SSH tunnel from local port 2222 on host with IP address 10.10.10.10 to port 222 on external server with IP address 11.11.11.11.
+* Writes a systemd user unit file with the path *~/.config/systemd/user/ssh-tunnel-from-2222-to-vmserver.service*
+* Starts the *ssh-tunnel-from-2222-to-vmserver.service* and enables automatic start-up of the service.
+
+## rm-ssh-tunnel
+Remove a persistent SSH tunnel between servers created by the [make-ssh-tunnel](#make-ssh-tunnel).
+It stops and removes the systmed service and related user unit files.
+
+To remove the SSH tunnel and the service created by the above [example](#example):
+```
+rm-ssh-tunnel --port 3333 vmserver
+```
+
+### Full usage and options
+```
+rm-ssh-tunnel -h
+```

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -28,7 +28,7 @@ make-ssh-tunnel -h
 
 ### Example
 ```
-make-ssh-tunnel --ip 10.10.10.10 --server 11.11.11.11 --user ubuntu --port 3333 --to-port 333 vmserver
+make-ssh-tunnel --bind 10.10.10.10 --port 3333 --ip 11.11.11.11 --to-port 333 --user ubuntu vmserver
 ```
 * Creates a persistent SSH tunnel from local port 3333 on host with IP address 10.10.10.10 to port 333 on external server with IP address 11.11.11.11.
 * Writes a systemd user unit file with the path *~/.config/systemd/user/ssh-tunnel-from-3333-to-vmserver.service*

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -30,9 +30,9 @@ make-ssh-tunnel -h
 ```
 make-ssh-tunnel --ip 10.10.10.10 --server 11.11.11.11 --user ubuntu --port 3333 --to-port 333 vmserver
 ```
-* Creates a persistent SSH tunnel from local port 2222 on host with IP address 10.10.10.10 to port 222 on external server with IP address 11.11.11.11.
-* Writes a systemd user unit file with the path *~/.config/systemd/user/ssh-tunnel-from-2222-to-vmserver.service*
-* Starts the *ssh-tunnel-from-2222-to-vmserver.service* and enables automatic start-up of the service.
+* Creates a persistent SSH tunnel from local port 3333 on host with IP address 10.10.10.10 to port 333 on external server with IP address 11.11.11.11.
+* Writes a systemd user unit file with the path *~/.config/systemd/user/ssh-tunnel-from-3333-to-vmserver.service*
+* Starts the *ssh-tunnel-from-3333-to-vmserver.service* and enables automatic start-up of the service.
 
 ## rm-ssh-tunnel
 Remove a persistent SSH tunnel between servers created by the [make-ssh-tunnel](#make-ssh-tunnel).

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -35,7 +35,7 @@ make-ssh-tunnel --bind 10.10.10.10 --port 3333 --ip 11.11.11.11 --to-port 333 --
 * Starts the *ssh-tunnel-from-3333-to-vmserver.service* and enables automatic start-up of the service.
 
 ## rm-ssh-tunnel
-Remove a persistent SSH tunnel between servers created by the [make-ssh-tunnel](#make-ssh-tunnel).
+Removes a persistent SSH tunnel between servers created by the [make-ssh-tunnel](#make-ssh-tunnel).
 It stops and removes the systmed service and related user unit files.
 
 To remove the SSH tunnel and the service created by the above [example](#example):

--- a/ssh/make-ssh-tunnel
+++ b/ssh/make-ssh-tunnel
@@ -85,7 +85,7 @@ usage() {
 # Handling command line arguments
 #######################################
 if ! OPTS="$(getopt \
-  --longoptions help,ip:,server:user:,port:,to-port: \
+  --longoptions help,ip:,server:,user:,port:,to-port: \
   --options hi:s:u:p:t: \
   --name "$(basename "$0")" \
   -- "$@"

--- a/ssh/make-ssh-tunnel
+++ b/ssh/make-ssh-tunnel
@@ -28,7 +28,7 @@ DIR=$(dirname "$0")
 NAME=external
 
 # Local IP address
-IP=10.10.10.10
+IP=0.0.0.0
 
 # IP address of the external server/VM/etc. to connect with the tunnel
 TO_IP=10.10.20.10
@@ -59,21 +59,24 @@ usage() {
   echo
   echo "Options:"
   echo "  -h, --help            Displays help on commandline options"
-  echo "  -i, --ip <ip>	        Local IP address"
-  echo "			With value 0.0.0.0 it would be binding"
-  echo "			on all interfaces on local server"
-  echo "  -s, --server <ip>	IP address of the external server"
-  echo "  -u, --user <user>	User in the external server"
-  echo "  -p, --port <port>	Local port which is forwarded to the"
-  echo "			external server to create the tunnel"
-  echo "			Default: 2222"
+  echo "  -b, --bind <ip>       Bind address, like local IP address"
+  echo "                        (connection bound to specific address),"
+  echo "                        127.0.0.01 (bound for local use only),"
+  echo "                        0.0.0.0 (available from all interfaces)"
+  echo "                        Default: 0.0.0.0"
+  echo "  -i, --ip <ip>         IP address of the external server"
+  echo "  -u, --user <user>     User in the external server"
+  echo "                        Default: ubuntu"
+  echo "  -p, --port <port>     Local port which is forwarded to the"
+  echo "                        external server to create the tunnel"
+  echo "                        Default: 2222"
   echo "  -t, --to-port <port>  Port on the external server"
-  echo "			Default: 22"
+  echo "                        Default: 22"
   echo
   echo "Arguments:"
-  echo "  name			Name and identifier for the tunnel."
-  echo "			It will be a part of the name for the"
-  echo "			created service:"
+  echo "  name                  Name and identifier for the tunnel."
+  echo "                        It will be a part of the name for the"
+  echo "                        created service:"
   echo "                        ssh-tunnel-from-<port>-to-<name>.service"
 }
 
@@ -85,8 +88,8 @@ usage() {
 # Handling command line arguments
 #######################################
 if ! OPTS="$(getopt \
-  --longoptions help,ip:,server:,user:,port:,to-port: \
-  --options hi:s:u:p:t: \
+  --longoptions help,bind:,ip:,user:,port:,to-port: \
+  --options hb:i:u:p:t: \
   --name "$(basename "$0")" \
   -- "$@"
 )"; then
@@ -97,8 +100,8 @@ eval set -- "$OPTS"
 while true; do
   case "$1" in
     --help|-h) usage; exit ;;
-    --ip|-i) IP="$2"; shift 2 ;;
-    --server|-s) TO_IP="$2"; shift 2 ;;
+    --bind|-b) IP="$2"; shift 2 ;;
+    --ip|-i) TO_IP="$2"; shift 2 ;;
     --port|-p) PORT="$2"; shift 2 ;;
     --to-port|-t) TO_PORT="$2"; shift 2 ;;
     --user|-u) LOGIN="$2"; shift 2 ;;

--- a/ssh/make-ssh-tunnel
+++ b/ssh/make-ssh-tunnel
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Makes a persistent SSH tunnel between servers with systemd.
+#
+# Uses the ssh-tunnel-persistent.service template file to write
+# systemd unit file. The tempalate file must be on the same directory
+# with this tool.
+#
+# Created user unit is placed in ~/.config/systemd/user/.
+# User service is started and enabled to be autostarted on reboot.
+# It can run without any open sessions (loginctl enable-linger $USER).
+#
+# Check the usage() function below for more usage options
+
+#######################################
+# Shell options
+#######################################
+set -e
+
+#######################################
+# DEFAULT VALUES
+#######################################
+
+# Path of the executing script
+DIR=$(dirname "$0")
+
+# name for tunnel/server/VM/etc. to identify the created systemd service
+NAME=external
+
+# Local IP address
+IP=10.10.10.10
+
+# IP address of the external server/VM/etc. to connect with the tunnel
+TO_IP=10.10.20.10
+
+# User on the external server to connect with the tunnel
+LOGIN=ubuntu
+
+# Local port which is forwarded to the external server/VM/etc.
+PORT=2222
+
+# Port on the external server to connect through the tunnel
+TO_PORT=22
+
+#######################################
+# USAGE
+#######################################
+
+usage() {
+  echo "Usage: $0 [options] <name>"
+  echo
+  echo "Creates a persistent SSH tunnel between servers with systemd"
+  echo
+  echo "Writes a systemd user unit file which enables persistent SSH"
+  echo "tunnel from a local port to a port on an external server."
+  echo "Starts the service and enables the service to be autostarted."
+  echo "Enables the user process for the service to run without any"
+  echo "open sessions on the local host."
+  echo
+  echo "Options:"
+  echo "  -h, --help            Displays help on commandline options"
+  echo "  -i, --ip <ip>	        Local IP address"
+  echo "			With value 0.0.0.0 it would be binding"
+  echo "			on all interfaces on local server"
+  echo "  -s, --server <ip>	IP address of the external server"
+  echo "  -u, --user <user>	User in the external server"
+  echo "  -p, --port <port>	Local port which is forwarded to the"
+  echo "			external server to create the tunnel"
+  echo "			Default: 2222"
+  echo "  -t, --to-port <port>  Port on the external server"
+  echo "			Default: 22"
+  echo
+  echo "Arguments:"
+  echo "  name			Name and identifier for the tunnel."
+  echo "			It will be a part of the name for the"
+  echo "			created service:"
+  echo "                        ssh-tunnel-from-<port>-to-<name>.service"
+}
+
+#######################################
+# EXECUTION
+#######################################
+
+#######################################
+# Handling command line arguments
+#######################################
+if ! OPTS="$(getopt \
+  --longoptions help,ip:,server:user:,port:,to-port: \
+  --options hi:s:u:p:t: \
+  --name "$(basename "$0")" \
+  -- "$@"
+)"; then
+  usage
+  exit 1
+fi
+eval set -- "$OPTS"
+while true; do
+  case "$1" in
+    --help|-h) usage; exit ;;
+    --ip|-i) IP="$2"; shift 2 ;;
+    --server|-s) TO_IP="$2"; shift 2 ;;
+    --port|-p) PORT="$2"; shift 2 ;;
+    --to-port|-t) TO_PORT="$2"; shift 2 ;;
+    --user|-u) LOGIN="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) echo "DEBUG: No implementation for the option $1" ; exit 1 ;;
+  esac
+done
+ARGS=("$@")
+ARGCOUNT=${#ARGS[@]}
+if [ "$ARGCOUNT" -eq "1" ]; then
+  NAME="${ARGS[0]}"
+elif [ "$ARGCOUNT" -gt "1" ]; then
+  echo "Too many arguments supplied."
+  usage
+  exit 1
+fi
+
+#######################################
+# Main Execution
+#######################################
+
+# Name of the service to be created to establish the persistent tunnel
+SERVICE_NAME=ssh-tunnel-from-$PORT-to-$NAME.service
+# Path to the user unit
+UNIT_FILE=~/.config/systemd/user/$SERVICE_NAME
+
+echo "Writing the systemd user unit to $UNIT_FILE .."
+mkdir -p ~/.config/systemd/user/
+cat $DIR/ssh-tunnel-persistent.service \
+  | sed "s/HOST/${IP}/g" \
+  | sed "s/LOCAL/${PORT}/g" \
+  | sed "s/SERVER/${TO_IP}/g" \
+  | sed "s/PORT/${TO_PORT}/g" \
+  | sed "s/USER/${LOGIN}/g" \
+  | tee $UNIT_FILE > /dev/null
+
+echo "Enabling the service to be autostarted .."
+systemctl --user enable $SERVICE_NAME
+echo "Starting the service .."
+systemctl --user start $SERVICE_NAME
+echo "Enabling user process to run without any open sessions .."
+loginctl enable-linger $USER
+systemctl --user status $SERVICE_NAME

--- a/ssh/rm-ssh-tunnel
+++ b/ssh/rm-ssh-tunnel
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Remves a persistent SSH tunnel created by the make-ssh-tunnel.
+# Removes a persistent SSH tunnel created by the make-ssh-tunnel.
 #
 # Check the usage() function below for more usage options
 

--- a/ssh/rm-ssh-tunnel
+++ b/ssh/rm-ssh-tunnel
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Remves a persistent SSH tunnel created by the make-ssh-tunnel.
+#
+# Check the usage() function below for more usage options
+
+#######################################
+# Shell options
+#######################################
+set -e
+
+#######################################
+# DEFAULT VALUES
+#######################################
+
+# name for tunnel/server/VM/etc. to identify the systemd service
+NAME=external
+
+# Local port which is forwarded to the external server/VM/etc.
+PORT=2222
+
+#######################################
+# USAGE
+#######################################
+
+usage() {
+  echo "Usage: $0 [options] <name>"
+  echo
+  echo "Removes a persitent SSH tunnel created by the make-ssh-tunnel"
+  echo
+  echo "Removes a systemd user unit file which enabled persistent SSH"
+  echo "tunnel from a local port to a port on an external server."
+  echo "Stops and disables the service."
+  echo
+  echo "Options:"
+  echo "  -h, --help            Displays help on commandline options"
+  echo "  -p, --port <port>	Local port which is forwarded to the"
+  echo "			external server to create the tunnel"
+  echo "			Default: 2222"
+  echo
+  echo "Arguments:"
+  echo "  name			Name and identifier for the tunnel."
+  echo "			It will be a part of the service name:"
+  echo "                        ssh-tunnel-from-<port>-to-<name>.service"
+}
+
+#######################################
+# EXECUTION
+#######################################
+
+#######################################
+# Handling command line arguments
+#######################################
+if ! OPTS="$(getopt \
+  --longoptions help,port: \
+  --options hp: \
+  --name "$(basename "$0")" \
+  -- "$@"
+)"; then
+  usage
+  exit 1
+fi
+eval set -- "$OPTS"
+while true; do
+  case "$1" in
+    --help|-h) usage; exit ;;
+    --port|-p) PORT="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) echo "DEBUG: No implementation for the option $1" ; exit 1 ;;
+  esac
+done
+ARGS=("$@")
+ARGCOUNT=${#ARGS[@]}
+if [ "$ARGCOUNT" -eq "1" ]; then
+  NAME="${ARGS[0]}"
+elif [ "$ARGCOUNT" -gt "1" ]; then
+  echo "Too many arguments supplied."
+  usage
+  exit 1
+fi
+
+#######################################
+# Main Execution
+#######################################
+
+# Name of the service to be created to establish the persistent tunnel
+SERVICE_NAME=ssh-tunnel-from-$PORT-to-$NAME.service
+# Path to the user unit
+UNIT_FILE=~/.config/systemd/user/$SERVICE_NAME
+
+echo "Stopping the service .."
+systemctl --user stop $SERVICE_NAME
+echo "Disabling the service .."
+systemctl --user disable $SERVICE_NAME
+echo "Removing the systemd user unit from $UNIT_FILE .."
+rm $UNIT_FILE
+echo "Unit $SERVICE_NAME removed."
+

--- a/ssh/ssh-tunnel-persistent.service
+++ b/ssh/ssh-tunnel-persistent.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Persistent SSH tunnel from port LOCAL to port PORT on SERVER
+After=network.target
+
+[Service]
+Restart=always
+RestartSec=3
+ExecStart=/usr/bin/ssh -NTC -o ServerAliveInterval=60 -o\
+ ExitOnForwardFailure=yes -L HOST:LOCAL:SERVER:PORT\
+ USER@SERVER
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Evaluate the command which adds SSH tunnel from host to the guest VM properly so it is always executed.

Includes also some minor cosmetic changes +
new default IP addresses for host and VM (for testing purposes)

Signed-off-by: Marko Kaapu <marko.kaapu@unikie.com>