### PR TITLE
Add vm-utility development tools

### DIFF
--- a/development/config-git
+++ b/development/config-git
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+NAME=
+MAIL=
+EDIT=
+
+usage() {
+  echo "Usage: $0 [options]"
+  echo
+  echo "Sets git configuration for a developer."
+  echo
+  echo "Example:"
+  echo "$ $0 --email spiderman@gmail.com --editor nano \"Peter Parker\""
+  echo
+  echo "Options:"
+  echo "  -h, --help                    Displays help on commandline options"
+  echo "  -a, --email <user.email>      Your email address"
+  echo "  -e, --editor <core.editor>    Your text editor"
+  echo "Arguments:"
+  echo "  \"User Name\"                   Your name"
+}
+
+if ! OPTS="$(getopt \
+  --longoptions help,name:,email:,editor: \
+  --options hn:a:e: \
+  --name "$(basename "$0")" \
+  -- "$@"
+)"; then
+  usage
+  exit 1
+fi
+eval set -- "$OPTS"
+while true; do
+  case "$1" in
+    --help|-h) usage; exit ;;
+    --email|-a) MAIL="$2"; shift 2 ;;
+    --editor|-e) EDIT="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) echo "DEBUG: No implementation for the option $1" ; exit 1 ;;
+  esac
+done
+ARGS=("$@")
+ARGCOUNT=${#ARGS[@]}
+if [ "${ARGCOUNT}" -eq "0" ]; then
+  echo "$0: No arguments supplied."
+elif [ "${ARGCOUNT}" -gt "1" ]; then
+  echo "$0: Unexpected arguments supplied."
+  usage
+  exit 1
+fi
+
+git config --global user.name "$ARGS"
+if [ "$MAIL" ]; then
+  git config --global user.email $MAIL
+fi
+if [ "$EDIT" ]; then
+  git config --global core.editor $EDIT
+fi
+git config \
+  --global url.ssh://git@github.com/.insteadOf https://github.com/

--- a/development/config-nano
+++ b/development/config-nano
@@ -1,0 +1,2 @@
+echo set constantshow > ~/.nanorc
+echo set guidestripe 72 >> ~/.nanorc

--- a/development/dev-vm
+++ b/development/dev-vm
@@ -4,14 +4,15 @@
 #
 # Installs Multipass tool if not already installed.
 # Launches a new Multipass instance using mp-launch tool.
-# On the launched instance, creates a workspace directory
-# and clones the vm-utility repository there.
-# With --branch option, checkouts a new local branch.
-# With --track option, sets a remote-tracking branch.
-# Sets up your identity (--name and --email options)
+# On the launched instance:
+# - Creates a workspace directory and clones the vm-utility there.
+# - Sets up vm-utility and Multipass tools in the VM.
+# - With --branch option, checkouts a new local branch.
+# - With --track option, sets a remote-tracking branch.
+# - Sets up your identity (--name and --email options)
 # and configures the default text editor (--editor option) for Git.
-# Creates a simple initial configuration file for nano.
-# Generates a new SSH key on the instance and prints the public key.
+# - Creates a simple initial configuration file for nano.
+# - Generates a new SSH key on the instance and prints the public key.
 #
 set -e
 
@@ -188,6 +189,10 @@ fi
 echo
 echo "Installing vm-utility.."
 ./setup
+
+echo
+echo "Installing multipass.."
+setup-multipass
 
 echo
 echo "Customizing Git environment.."

--- a/development/dev-vm
+++ b/development/dev-vm
@@ -4,7 +4,7 @@
 #
 # Installs Multipass tool if not already installed.
 # Launches a new Multipass instance using mp-launch tool.
-# On launched instance, creates a workspace directory
+# On the launched instance, creates a workspace directory
 # and clones the vm-utility repository there.
 # With --branch option, checkouts a new local branch.
 # With --track option, sets a remote-tracking branch.
@@ -150,7 +150,7 @@ EXEC_ARGS+=( "$MAIL" )
 EXEC_ARGS+=( "$EDIT" )
 EXEC_ARGS+=( "$BRANCH" )
 EXEC_ARGS+=( "$REMOTE" )
-multipass exec $VM_NAME -- bash -c ' # Following run on the VM
+multipass exec $VM_NAME -- bash -c ' # Run on the VM
 
 # VM environment
 VM_NAME=$0
@@ -160,7 +160,7 @@ EDIT=$3
 BRANCH=$4
 REMOTE=$5
 CHECKOUT=( "git checkout" )
-GIT_SETUP=( "development/config-git" )
+GIT_SETUP=( "config-git" )
 WORKSPACE=~/workspace
 
 mkdir $WORKSPACE
@@ -191,7 +191,7 @@ echo "Installing vm-utility.."
 
 echo
 echo "Customizing Git environment.."
-development/config-nano
+config-nano
 if [ $MAIL ]; then
   GIT_SETUP+=( "-a $MAIL" )
 fi

--- a/development/dev-vm
+++ b/development/dev-vm
@@ -199,7 +199,8 @@ if [ $EDIT ]; then
   GIT_SETUP+=( "-e $EDIT" )
 fi
 GIT_SETUP+=( "\"$NAME\"" )
-${GIT_SETUP[@]}
+eval "${GIT_SETUP[@]}"
+git config --list --show-origin
 
 echo
 echo "Generating a new SSH key.."

--- a/development/dev-vm
+++ b/development/dev-vm
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# Create vm-utility development environment inside a new VM instance.
+#
+# Installs Multipass tool if not already installed.
+# Launches a new Multipass instance using mp-launch tool.
+# On launched instance, creates a workspace directory
+# and clones the vm-utility repository there.
+# With --branch option, checkouts a new local branch.
+# With --track option, sets a remote-tracking branch.
+# Sets up your identity (--name and --email options)
+# and configures the default text editor (--editor option) for Git.
+# Creates a simple initial configuration file for nano.
+# Generates a new SSH key on the instance and prints the public key.
+#
+set -e
+
+#######################################
+# DEFAULT VALUES
+#######################################
+
+DIR=$(dirname "$0")
+NAME=
+MAIL=
+EDIT="nano"
+BRANCH=
+REMOTE=
+CPUS="4"
+DISK="128G"
+MEMORY="16G"
+VM_NAME="primary"
+BRANCH=
+MOUNT=
+IP=
+
+#######################################
+# USAGE
+#######################################
+
+usage() {
+  echo "Usage: $0 [options]"
+  echo
+  echo "Creates and starts a new VM for vm-utility development."
+  echo
+  echo "Example:"
+  echo "$ $0 -n \"Peter Parker\" -a peter.parker@gmail.com -e nano -b web-dev spider-verse"
+  echo
+  echo "Options:"
+  echo "  -h, --help                            Displays help on commandline options"
+  echo "  -n, --name \"<user.name>\"              \"Your name\" (for git config)"
+  echo "  -a, --email <user.email>              Your email address (for git config)"
+  echo "  -e, --editor <core.editor>            Your text editor (for git config)"
+  echo "  -b, --branch <branch>                 Name of a local branch to checkout"
+  echo "  -t, --track <remote>/<branch>         Name of a remote-tracking branch"
+  echo "  -c, --cpus <cpus>                     Numbers of CPUs to allocate."
+  echo "                                        Minimum: 1, default: 4."
+  echo "  -d, --disk <disk>                     Disk space to allocate. Positive"
+  echo "                                        integers, in bytes, or with K, M, G"
+  echo "                                        suffix."
+  echo "                                        Minimum: 512M, default: 128G."
+  echo "  -m, --memory <mem>                    Amount of memory to allocate. Positive"
+  echo "                                        integers, in bytes, or with K, M, G"
+  echo "                                        suffix"
+  echo "                                        Minimum: 128M, default: 16G."
+  echo "  -i, --ip <ip>                         Sets a static IP address for the"
+  echo "                                        instance. Note that there will be no"
+  echo "                                        IP address conflict detection with"
+  echo "                                        any existing addresses."
+  echo "  --mount <local-path>:<vm-path>        Mount a local directory inside the"
+  echo "                                        instance. If <vm-path> is omitted,"
+  echo "                                        the mount point will be the same as the"
+  echo "                                        absolute path of <local-path>"
+  echo "Arguments:"
+  echo "  vm-name                               Name for the instance. If it is"
+  echo "                                        'primary' (the configured primary"
+  echo "                                        instance name), the user's home"
+  echo "                                        directory is mounted inside the newly"
+  echo "                                        launced instance, in 'Home'."
+  echo "                                        Default: primary"
+}
+
+#######################################
+# EXECUTION
+#######################################
+
+#######################################
+# Handling command line arguments
+#######################################
+
+if ! OPTS="$(getopt \
+  --longoptions help,name:,email:,editor:,branch:,track:,cpus:,disk:,\
+memory:,ip:,mount: \
+  --options hn:a:e:b:t:c:d:m:i: \
+  --name "$(basename "$0")" \
+  -- "$@"
+)"; then
+  usage
+  exit 1
+fi
+eval set -- "$OPTS"
+while true; do
+  case "$1" in
+    --help|-h) usage; exit ;;
+    --name|-n) NAME="$2"; shift 2 ;;
+    --email|-a) MAIL="$2"; shift 2 ;;
+    --editor|-e) EDIT="$2"; shift 2 ;;
+    --branch|-b) BRANCH="$2"; shift 2 ;;
+    --track|-t) REMOTE="$2"; shift 2 ;;
+    --cpus|-c) CPUS="$2"; shift 2 ;;
+    --disk|-d) DISK="$2"; shift 2 ;;
+    --memory|-m) MEMORY="$2"; shift 2 ;;
+    --ip|-i) IP="$2"; shift 2 ;;
+    --mount) MOUNT="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) echo "DEBUG: No implementation for the option $1" ; exit 1 ;;
+  esac
+done
+ARGS=("$@")
+ARGCOUNT=${#ARGS[@]}
+if [ "$ARGCOUNT" -eq "1" ]; then
+  VM_NAME="${ARGS[0]}"
+elif [ "$ARGCOUNT" -gt "1" ]; then
+  ERRORS+=("Too many arguments supplied.")
+fi
+
+#######################################
+# Main Execution
+#######################################
+
+# Install multipass if not installed
+# and wait that multipassd is running.
+setup-multipass
+
+echo
+echo "Creating and launching the $VM_NAME instance.."
+LAUNCH=( "mp-launch -k -n $VM_NAME -c $CPUS -m $MEMORY -d $DISK" )
+if [ $IP ]; then
+  LAUNCH+=("-i $IP")
+fi
+if [ $MOUNT ];then
+  LAUNCH+=("--mount $MOUNT")
+fi
+${LAUNCH[@]}
+
+echo
+echo "Setting up the $VM_NAME for development.."
+EXEC_ARGS+=( "$VM_NAME" )
+EXEC_ARGS+=( "$NAME" )
+EXEC_ARGS+=( "$MAIL" )
+EXEC_ARGS+=( "$EDIT" )
+EXEC_ARGS+=( "$BRANCH" )
+EXEC_ARGS+=( "$REMOTE" )
+multipass exec $VM_NAME -- bash -c ' # Following run on the VM
+
+# VM environment
+VM_NAME=$0
+NAME=$1
+MAIL=$2
+EDIT=$3
+BRANCH=$4
+REMOTE=$5
+CHECKOUT=( "git checkout" )
+GIT_SETUP=( "development/config-git" )
+WORKSPACE=~/workspace
+
+mkdir $WORKSPACE
+cd $WORKSPACE
+echo "The workspace directory created: $WORKSPACE"
+
+echo
+echo "Cloning vm-utility to the workspace from GitHub.."
+git clone https://github.com/mkaapu/vm-utility.git
+cd vm-utility
+
+if [ $BRANCH ] || [ $REMOTE ]; then
+  echo
+  echo "Setting up a local development branch.."
+  if [ $BRANCH ] && [ $REMOTE ]; then
+    CHECKOUT+=( "-b $BRANCH $REMOTE" )
+  elif [ $REMOTE ]; then
+    CHECKOUT+=( "--track $REMOTE" )
+  else
+    CHECKOUT+=( "-b $BRANCH" )
+  fi
+  ${CHECKOUT[@]}
+fi
+
+echo
+echo "Installing vm-utility.."
+./setup
+
+echo
+echo "Customizing Git environment.."
+development/config-nano
+if [ $MAIL ]; then
+  GIT_SETUP+=( "-a $MAIL" )
+fi
+if [ $EDIT ]; then
+  GIT_SETUP+=( "-e $EDIT" )
+fi
+GIT_SETUP+=( "\"$NAME\"" )
+${GIT_SETUP[@]}
+
+echo
+echo "Generating a new SSH key.."
+ssh-keygen -q -t ed25519 -f ~/.ssh/id_ed25519 -N ""
+echo "Add the newly generated public SSH key on the $VM_NAME:"
+cat ~/.ssh/id_ed25519.pub
+echo "to:"
+echo "https://github.com/settings/keys"
+echo "and"
+echo "$VM_NAME:$WORKSPACE/vm-utility is ready for development."
+
+' "${EXEC_ARGS[@]}" # Arguments passed for bash on the VM as an array

--- a/development/purge-vm
+++ b/development/purge-vm
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Deletes and purges multipass instance.
+# Removes any known host keys with IP addresses of deleted instances.
+
+set -e
+
+. mp-calls
+
+usage() {
+  echo "Usage: $0 [vm-name]..."
+  echo
+  echo "Deletes and purges multipass instances."
+  echo
+  echo "Removes also any stored known host keys with IP addresses"
+  echo "of the instances from .ssh/known_hosts."
+}
+
+# arguments
+instances=($@)
+if [ "${#instances[@]}" -eq "0" ]; then
+  usage
+  exit
+fi
+
+# remove instances from known hosts
+for i in "${instances[@]}"; do
+  ip=$(mp-info-ip $i)
+  if [ $ip ]; then
+    ssh-keygen -R $ip
+  fi
+done
+
+# delete and purge instances
+multipass delete ${instances[@]}
+multipass purge
+multipass list

--- a/installers/multipass/setup-multipass
+++ b/installers/multipass/setup-multipass
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Installs Multipass and waits while multipassd service is running.
+#
+# Reference: https://multipass.run/install
+
+set -e
+
+echo
+echo "Installing Multipass tool.."
+sudo snap install multipass
+
+echo
+echo "Waiting while multipassd service has been started.."
+echo "If Multipass is not starting up it can be restarted manually:"
+echo "$ sudo snap restart multipass.multipassd"
+while true; do
+  if pgrep -x "multipassd" > /dev/null; then
+    if [ -a /var/snap/multipass/common/multipass_socket ]; then
+      echo
+      echo Multipass is running.
+      break
+    fi
+  fi
+done

--- a/jenkins/vm-agent/launch-vm-agent
+++ b/jenkins/vm-agent/launch-vm-agent
@@ -86,23 +86,9 @@ if [ "${#ARGS[@]}" -ne "0" ]; then
   exit 1
 fi
 
-echo
-echo "Installing Multipass tool.."
-sudo snap install multipass
-
-echo
-echo "Waiting while multipassd service has been started.."
-echo "If Multipass is not starting up it can be restarted manually:"
-echo "$ sudo snap restart multipass.multipassd"
-while true; do
-  if pgrep -x "multipassd" > /dev/null; then
-    if [ -a /var/snap/multipass/common/multipass_socket ]; then
-      echo
-      echo Multipass is running.
-      break
-    fi
-  fi
-done
+# Install multipass if not installed
+# and wait that multipassd is running.
+setup-multipass
 
 echo
 echo "Creating Ubuntu LTS VM instance: $NAME with a static IP: $VM_IP"

--- a/setup
+++ b/setup
@@ -87,5 +87,10 @@ sudo cp -v $INTERACTIVE \
   $UTILITY_DIR/ssh/make-ssh-tunnel \
   $UTILITY_DIR/ssh/rm-ssh-tunnel \
   $UTILITY_DIR/ssh/ssh-tunnel-persistent.service \
+  $UTILITY_DIR/installers/multipass/setup-multipass \
+  $UTILITY_DIR/development/config-nano \
+  $UTILITY_DIR/development/config-git \
+  $UTILITY_DIR/development/dev-vm \
+  $UTILITY_DIR/development/purge-vm \
   $DESTINATION.
 echo "vm-utility installed."

--- a/test/test-vm-agent
+++ b/test/test-vm-agent
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Tests vm-utility tools
+#
+# Run this test from the root of the repository:
+# $ test/test-vm-agent
+
+set -e
+
+HOST_VM="test-vm-agent"
+GUEST_VM="vm-agent"
+CURRENT_BRANCH=$(git branch --show-current)
+echo $CURRENT_BRANCH
+
+echo "Setting up the test environment.."
+echo "Copying vm-utility tools to /usr/local/bin .."
+./setup
+. mp-calls
+
+echo "Cleaning the test environment.."
+ssh-keygen -R "[10.10.10.10]:2222"
+host_found=$(mp-info-ip $HOST_VM)
+if [ $host_found ]; then
+  echo "$HOST_VM found."
+  multipass exec $HOST_VM -- bash -c '
+    . mp-calls
+    guest_found=$(mp-info-ip $0)
+    if [ $guest_found ]; then
+      echo "$0 found."
+      purge-vm $0
+      echo "$0 purged."
+    else
+      echo "$0 not found."
+    fi
+  ' $GUEST_VM
+  purge-vm $HOST_VM
+  echo "$HOST_VM purged."
+else
+  echo "$HOST_VM not found."
+fi
+echo "Test environment clean."
+
+echo
+echo "1. Testing the dev-vm tool."
+echo "Creating a test host VM:$HOST_VM with the IP:10.10.10.10 .."
+dev-vm \
+  -n "John Doe" \
+  -a johndoe@example.com \
+  -i 10.10.10.10 \
+  -t origin/$CURRENT_BRANCH \
+  $HOST_VM
+echo "1. VM:$HOST_VM creation: SUCCESS!"
+
+echo
+echo "2. Testing the launch-vm-agent tool."
+echo "Creating a guest VM:$GUEST_VM in the VM:$HOST_VM with the tool .."
+EXEC_ARGS+=( "$GUEST_VM" )
+EXEC_ARGS+=( "$CURRENT_BRANCH" )
+EXEC_ARGS+=( "$(cat ~/.ssh/id_ed25519.pub)" )
+multipass exec $HOST_VM -- bash -c '
+
+  GUEST_VM=$0
+  BRANCH=$1
+  KEY="$2"
+  set -e
+  launch-vm-agent \
+    --name $GUEST_VM \
+    --cpus 2 \
+    --mem 2G \
+    --disk 10G \
+    --host-ip 10.10.10.10 \
+    --vm-ip 10.10.20.10
+  echo "2. VM:$GUEST_VM creation: SUCCESS!"
+
+  echo
+  echo "3. Testing the setup-docker script"
+  echo "Install Docker inside the VM:$GUEST_VM using the script"
+  multipass exec $GUEST_VM -- bash -c "
+    set -e
+    mkdir -p workspace
+    cd workspace
+    git clone https://github.com/mkaapu/vm-utility.git
+    cd vm-utility
+    git checkout -t origin/$BRANCH
+    installers/docker/setup-docker
+  " $BRANCH
+
+  multipass exec $GUEST_VM -- docker run hello-world
+  echo "Docker commands can run without sudo on the VM:$GUEST_VM"
+  echo "3. VM:$GUEST_VM Docker setup: SUCCESS!"
+
+  multipass exec $GUEST_VM -- bash -c "
+    echo $KEY >> ~/.ssh/authorized_keys
+  " $KEY
+  echo
+  echo "Public key of the current user authorized on the VM:$GUEST_VM"
+
+' "${EXEC_ARGS[@]}"
+
+echo
+echo "Adding a known host key of the VM:$GUEST_VM to the current user.."
+ssh-keyscan \
+  -H \
+  -t ed25519 \
+  -T 30 \
+  -p 2222 \
+  10.10.10.10 >> ~/.ssh/known_hosts
+
+echo
+echo "You should be able to connect to the VM:$HOST_VM:"
+echo "$ ssh ubuntu@10.10.10.10"
+echo
+echo "You should be able to connect to the VM:$GUEST_VM:"
+echo "$ ssh -p 2222 ubuntu@10.10.10.10"


### PR DESCRIPTION
New:
development/config-git:
 - simple script for setting initial global git configuration with developer identity and default text editor

 development/config-nano:
 - simple script for setting simple initial nano configuration which shows line (row) and column numbers and sets a guide stripe for git commits

 development/dev-vm:
 - tool for creating a new VM for vm-utility development using above tools and for checking out a new local development branch or setting a remote -tracking branch

development/purge-vm:
 - tool for deleting and purging Multipass instances and removing possible known hosts keys created with mp-ssh tool

installers/multipass/setup-multipass:
 - simple script for installing Multipass and waiting until the multipassd service is running and usable

test/test-vm-agent:
- can be used as a regression test for the vm-utility

Modified:
jenkins/vm-agent/launch-vm-agent:
 - using the setup-multipass for installing the Multipass on the host

 setup:
 - Adds the new tools to /usr/local/bin

Signed-off-by: Marko Kaapu <marko.kaapu@unikie.com>