### PR TITLE
Add tools to remove and config VMs + simple test framework for scripts

### DIFF
--- a/multipass/README.md
+++ b/multipass/README.md
@@ -66,7 +66,7 @@ The systemd service unit will be disabled, stopped and removed, but the route it
 ## mp-delete
 The **mp-delete** deletes Multipass instances created or configured with or without the [mp-ssh](#mp-ssh) tool (or with any tool which is using the mp-ssh, like [mp-launch](#mp-launch)).
 
-The tool also deletes any services created for the deleted instances by the [mp-route](#mp-route). The known hosts keys set by [mp-ssh](#mp-ssh) tool (to enable promptless SSH connection from host to the VM) are also removed.
+The tool also deletes any services created for the deleted instances by the [mp-route](#mp-route) (but superuser privileges are needed to remove the services). The known hosts keys set by [mp-ssh](#mp-ssh) tool (to enable promptless SSH connection from host to the VM) are also removed.
 
 ### Full usage and options:
 ```
@@ -88,5 +88,5 @@ mp-delete -p my-vm test-vm
 ```
 Delete and purge all VM instances configured with the [mp-ssh](#mp-ssh) or created with the [mp-launch](#mp-launch) (or any tool using those tools):
 ```
-mp-delete --all -p
+mp-delete -p --all
 ```

--- a/multipass/README.md
+++ b/multipass/README.md
@@ -62,3 +62,31 @@ Remove a systemd service enabling a route from host to the VM named 'my-vm' crea
 mp-route -d my-vm
 ```
 The systemd service unit will be disabled, stopped and removed, but the route itself is not automatically deleted until the host or its network is restarted. But the script will display a command in the terminal which can be used to manually remove the route.
+
+## mp-delete
+The **mp-delete** deletes Multipass instances created or configured with or without the [mp-ssh](#mp-ssh) tool (or with any tool which is using the mp-ssh, like [mp-launch](#mp-launch)).
+
+The tool also deletes any services created for the deleted instances by the [mp-route](#mp-route). The known hosts keys set by [mp-ssh](#mp-ssh) tool (to enable promptless SSH connection from host to the VM) are also removed.
+
+### Full usage and options:
+```
+mp-delete -h
+```
+
+### Examples
+Delete the VM instance named 'my-vm', to be purged with the `mp-delete --purge my-vm` (or with the `multipass purge`) command:
+```
+mp-delete my-vm
+```
+The above command will delete the VM instance but will not purge all its data, so you could recover the VM instance:
+```
+multipass recover my-vm
+```
+Delete and purge the VM instances named 'my-vm' and 'test-vm' and all their data immediately:
+```
+mp-delete -p my-vm test-vm
+```
+Delete and purge all VM instances configured with the [mp-ssh](#mp-ssh) or created with the [mp-launch](#mp-launch) (or any tool using those tools):
+```
+mp-delete --all -p
+```

--- a/multipass/mp-delete
+++ b/multipass/mp-delete
@@ -131,6 +131,12 @@ if $DELETE_ALL; then
   INSTANCES=( $(get_keys $VMU_IPS) )
 fi
 
+if [ ${#INSTANCES[@]} -eq 0 ]; then
+  echo "Name argument or --all is required"
+  usage
+  exit 1
+fi
+
 for vm in ${INSTANCES[@]}; do
 
   # Make the multipass delete command to delete the $vm

--- a/multipass/mp-delete
+++ b/multipass/mp-delete
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# Delete a Multipass instance.
+#
+# The script can be used to remove VM instances created by the mp-launch
+# or configured with the mp-ssh. It removes any persistent routes added
+# by the mp-ssh or mp-route tools. It also deletes the known hosts key
+# from the host set by the mp-ssh or mp-launch tools.
+#
+# Multipass installation is needed:
+# snap install multipass
+#
+# Superuser privileges are needed for removing a persistent route
+# from a host to a VM with a static IP.
+#
+# Check the usage() function below for more usage options
+
+#######################################
+# Shell options
+#######################################
+set -e
+
+#######################################
+# Includes
+#######################################
+. vmu-calls
+
+#######################################
+# DEFAULT VALUES
+#######################################
+
+# Level of logging verbosity (for the multipass delete command)
+VERBOSE=0
+
+# If true, deletes all VMs created or configured by the VM-utility tools
+DELETE_ALL=false
+
+# If true, VM instances and all their data will be purged permanently
+PURGE=false
+
+#######################################
+# FUNCTIONS
+#######################################
+
+#######################################
+# Usage
+# Arguments:
+#   None
+# Outputs:
+#   Writes usage to stdout
+#######################################
+usage() {
+  echo "Usage: $0 [options] <name> [<name> ...]"
+  echo
+  echo "Delete Multipass instances."
+  echo
+  echo "Tool can be used to delete Multipass instances created with"
+  echo "or without VM-utility tools."
+  echo
+  echo "Any known hosts keys of the deleted VMs will be also removed."
+  echo "Also any services created by the mp-route to persist routes"
+  echo "between the host and VM instances will be disabled and removed."
+  echo "Removing systemd services needs superuser privileges."
+  echo
+  echo "Options:"
+  echo "  -h, --help    Displays help on commandline options."
+  echo "  -v, --verbose Increase logging verbosity. Repeat the 'v' in the short option"
+  echo "                for more detail. Maximum verbosity is obtained with 4 (or more)"
+  echo "                 v's, i.e. -vvvv."
+  echo "  --all         Delete all instances configured by the VM-utility tools."
+  echo "  -p, --purge   Purge instances and all their data immediately."
+  echo
+  echo "Arguments:"
+  echo "  name          Names of instances to delete"
+}
+
+#######################################
+# EXECUTION
+#######################################
+
+#######################################
+# Handling command line arguments
+#######################################
+if ! OPTS="$(getopt \
+  --longoptions help,verbose,all,purge \
+  --options hvp \
+  --name "$(basename "$0")" \
+  -- "$@"
+)"; then
+  usage
+  exit 1
+fi
+eval set -- "$OPTS"
+while true; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit
+      ;;
+    --verbose|-v)
+      VERBOSE=$((VERBOSE+1))
+      shift
+      ;;
+    --all)
+      DELETE_ALL=true
+      shift
+      ;;
+    --purge|-p)
+      PURGE=true
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "DEBUG: No implementation for the option $1"
+      exit 1
+      ;;
+  esac
+done
+INSTANCES=("$@")
+
+#######################################
+# Main Execution
+#######################################
+
+ERROR_NRO=0
+
+if $DELETE_ALL; then
+  INSTANCES=( $(get_keys $VMU_IPS) )
+fi
+
+for vm in ${INSTANCES[@]}; do
+
+  # Make the multipass delete command to delete the $vm
+  delete_command=( "multipass delete" )
+  if $PURGE; then
+    delete_command+=( "--purge" )
+  fi
+  if [ "$VERBOSE" -gt 0 ]; then
+    varg="-"
+  for v in $(seq 1 $VERBOSE); do varg="${varg}v"; done
+    delete_command+=( $varg )
+  fi
+  delete_command+=( $vm )
+
+  if [ "$VERBOSE" -gt 0 ]; then echo; fi
+  # If deleting the $vm fails, do no delete any $vm related data
+  if ! ${delete_command[@]}; then
+    ERROR_NRO=$((ERROR_NRO+1))
+    continue
+  elif [ "$VERBOSE" -gt 0 ]; then
+    echo "VM instance: $vm deleted."
+  fi
+
+  # Remove the known hosts key of the VM instance
+  if ip=$(get_config $vm $VMU_IPS); then
+    if [ -f ~/.ssh/known_hosts ]; then
+      ssh-keygen -R $ip 2> /dev/null
+    fi
+  fi
+
+  # Unset the VMU configuration when VMU is purged
+  if $PURGE; then
+    unset_config $vm $VMU_IPS || true
+  fi
+
+  # Disable and remove a systemd service providing a persistent route
+  # from the host to the VM instance
+  systemd_unit=/etc/systemd/system/persistent-route-to-${vm}.service
+  if [ -a $systemd_unit ]; then
+    # needs superuser privileges
+    if ! mp-route -d $vm; then
+      ERROR_NRO=$((ERROR_NRO+1))
+    fi
+  fi
+
+done
+
+if [ $ERROR_NRO -gt 0 ]; then
+  echo
+  echo "$0: There were $ERROR_NRO error(s)."
+fi
+exit $ERROR_NRO

--- a/multipass/mp-route
+++ b/multipass/mp-route
@@ -219,8 +219,10 @@ UNIT_FILE=/etc/systemd/system/$SERVICE_NAME
 #######################################
 
 # Determine the IP address of the Multipass instance
-if [ -z "$IP" ]; then
-  IP=$(mp-info-ip $NAME)
+if [ ! $DELETE  ] && [ -z "$IP" ]; then
+  if ! IP=$(get_config $NAME $VMU_IPS); then
+    IP=$(mp-info-ip $NAME)
+  fi
 fi
 
 # Determine the needed route

--- a/multipass/mp-ssh
+++ b/multipass/mp-ssh
@@ -24,6 +24,7 @@ set -e
 #######################################
 # Includes
 #######################################
+. vmu-calls
 . net-calls
 . mp-calls
 
@@ -288,15 +289,12 @@ else
   mp-route -i $IP $NAME
 fi
 
+echo
+echo Updating ~/.ssh/known_hosts ..
 # Makes sure there will be no duplicate entries
 # with the same IP address in the known_hosts.
 if [ -f ~/.ssh/known_hosts ]; then
-  echo
-  echo Updating ~/.ssh/known_hosts ..
   ssh-keygen -R $IP 2> /dev/null
-else
-  echo
-  echo Updating ~/.ssh/known_hosts ..
 fi
 # Adds the public key to known_hosts file.
 if ! ssh-keyscan -H -t $TYPE -T $TIMEOUT $IP >> ~/.ssh/known_hosts
@@ -307,6 +305,10 @@ then
   ERRORS+=("Timeout seconds can be extended with the -T option.")
   exit_error
 fi
+
+# The IP address stored so the known hosts key can be removed
+# when the VM is purged
+set_config $NAME $IP $VMU_IPS
 
 echo
 echo "Open a shell prompt on the $NAME:"

--- a/multipass/mp-ssh
+++ b/multipass/mp-ssh
@@ -295,6 +295,12 @@ echo Updating ~/.ssh/known_hosts ..
 # with the same IP address in the known_hosts.
 if [ -f ~/.ssh/known_hosts ]; then
   ssh-keygen -R $IP 2> /dev/null
+  # When IP address is re-configured for the VM, remove old entries
+  if OLD_IP=$(get_config $NAME $VMU_IPS); then
+    if [ $OLD_IP != $IP ]; then
+      ssh-keygen -R $OLD_IP 2> /dev/null
+    fi
+  fi
 fi
 # Adds the public key to known_hosts file.
 if ! ssh-keyscan -H -t $TYPE -T $TIMEOUT $IP >> ~/.ssh/known_hosts
@@ -307,7 +313,7 @@ then
 fi
 
 # The IP address stored so the known hosts key can be removed
-# when the VM is purged
+# when the VM is purged or a new IP is configured for the VM
 set_config $NAME $IP $VMU_IPS
 
 echo

--- a/setup
+++ b/setup
@@ -108,6 +108,7 @@ ln -fsv $INTERACTIVE -t $BIN_DIR \
   $VMU_HOME/multipass/mp-ssh \
   $VMU_HOME/multipass/mp-launch \
   $VMU_HOME/multipass/mp-route \
+  $VMU_HOME/multipass/mp-delete \
   $VMU_HOME/jenkins/vm-agent/launch-vm-agent \
   $VMU_HOME/jenkins/vm-controller/launch-vm-jenkins \
   $VMU_HOME/ssh/make-ssh-tunnel \

--- a/test/test-calls
+++ b/test/test-calls
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Helper functions and variables implementing a simple test framework
+# for testing bash scripts
+#
+# An example of a test file content:
+# . test/test-calls
+# tcase "Find README.md file" ls -la | grep README.md
+# tcase "Check .gitignore" cat .gitignore | grep test-tmp
+# tsummary
+
+#######################################
+# GLOBAL VARIABLES
+#######################################
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BROWN='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+LGRAY='\033[0;37m'
+NC='\033[0m' # No color
+
+# Test report section marker
+SEPARATOR="#######################################"
+
+# Start of test summary as an array of strings
+SUMMARY=( "${LGRAY}$SEPARATOR" "SUMMARY" "$SEPARATOR${NC}" )
+
+# Test case ID counter
+TESTCID=0
+# Test set ID counter
+TESTSID=0
+
+
+# Number of tested cases
+TESTED=0
+# Number of failed cases
+FAILED=0
+
+#######################################
+# Run a test case
+#
+# If the exit status of the command is 0, verdict is SUCCESS.
+# If the exit status of the command is non-zero, verdict is FAILED.
+#
+# Test case information is collected to the global SUMMARY variable.
+# The summary can written to stdout by calling the tsummary function.
+#
+# Usage:
+#   tcase "List information about the test-calls file" ls test-calls
+#
+# Arguments:
+#   Name of the test case
+#   Command to be tested
+# Outputs:
+#   Exit status of the tested command is returned.
+#   Test case name, ID, command and verdict is written to stdout.
+#   The command output is written normally to stdout or stdin.
+#   Written output is wrapped to its own section.
+#######################################
+tcase() {
+
+  TESTCID=$((TESTCID+1))
+
+  local status=0
+  local name="$1"
+  local command="${@:2}"
+  local note=
+
+  echo
+  echo $SEPARATOR
+  echo "CASE ${TESTCID}: $name"
+  echo $SEPARATOR
+  set -x
+
+  $command
+  { status=$?; set +x; } 2>/dev/null
+
+  echo $SEPARATOR
+  if [ $status -eq 0 ]; then
+    note="CASE ${TESTCID}: ${GREEN}SUCCESS${NC}: $name"
+  else
+    note="CASE ${TESTCID}: ${RED}FAILED${NC}: $name"
+    FAILED=$((FAILED+1))
+  fi
+  echo -e $note
+  echo $SEPARATOR
+  TESTED=$((TESTED+1))
+  SUMMARY+=( "$note" )
+
+  return $status
+}
+
+#######################################
+# Run a command, script or function consisting a set of test cases
+#
+# If the exit status of the command is 0, verdict is SUCCESS.
+# If the exit status of the command is non-zero, verdict is FAILED.
+#
+# Can be used to call a test function which have multiple tcase calls
+# to wrap them up as a set of tests. Note that such a function needs
+# to return its exit status correctly to indicate if all tests passed
+# or if any of them failed.
+#
+# Test set information is written to the global SUMMARY variable.
+# The summary can written to stdout by calling the tsummary function.
+#
+# Usage:
+#   . my-test-set # includes a function called run-vmu-tests
+#   tcase "VMU tests" run-vmu-tests
+#
+# Arguments:
+#   Name of the test set
+#   Command or function to be executed
+# Outputs:
+#   Exit status of the tested command is returned.
+#   Test set name, ID, tcase outputs and status is written to stdin.
+#   The command output is written normally to sdtout or stdin.
+#   Written output is wrapped to its own section.
+#######################################
+tset() {
+
+  TESTSID=$((TESTSID+1))
+
+  local status=0
+  local set_name="$1"
+  local command="${@:2}"
+  local separator="${LGRAY}---------------------------------------"
+
+  echo
+  echo -e "${LGRAY}${SEPARATOR}"
+  echo "SET ${TESTSID}: ${set_name}"
+  echo -e "${SEPARATOR}${NC}"
+  SUMMARY+=( $separator "SET ${TESTSID}: ${set_name}${NC}" )
+
+  $command
+  status=$?
+
+  echo -e "${LGRAY}${SEPARATOR}"
+  summary_set="${LGRAY}SET ${TESTSID}${NC}: ${LGRAY}${set_name}${NC}"
+  if [ $status -eq 0 ]; then
+    echo -e "${GREEN}SUCCESS${NC}: ${summary_set}"
+    SUMMARY+=( "${summary_set}: ${GREEN}SUCCESS${NC}" )
+  else
+    echo -e "${RED}FAILED${NC}: ${summary_set}"
+    SUMMARY+=( "${summary_set}: ${RED}FAILED${NC}" )
+  fi
+  SUMMARY+=( "$separator${NC}" )
+  echo -e "${LGRAY}${SEPARATOR}${NC}"
+
+  return $status
+}
+
+#######################################
+# Run a command or a test step without any evaluated verdict
+#
+# Usage:
+#  tstep "Clean temporary test output" rm -rf test.tmp
+#
+# Arguments:
+#   Name of the test step
+#   Command to be executed
+# Outputs:
+#   Exit status of the test step is returned.
+#   Test step name is written to the stdout.
+#   The command output is written normally to stdout or stdin.
+#   Written output is wrapped to its own section.
+#######################################
+tstep() {
+
+  local status=0
+  local step="$1"
+  local command="${@:2}"
+  local separator="${LGRAY}---------------------------------------"
+
+  echo
+  echo -e $separator
+  echo "$step"
+  echo -e "$separator${NC}"
+
+  $command
+  status=$?
+
+  echo -e $separator
+  if [ $status -eq 0 ]; then
+    echo "DONE: $step"
+  else
+    echo -e "${RED}FAILED${LGRAY}: $step"
+  fi
+  echo -e "$separator${NC}"
+
+  return $status
+}
+
+#######################################
+# Write the summary of tests to stdout.
+#######################################
+tsummary() {
+  echo
+  for line in "${SUMMARY[@]}"; do
+    echo -e "$line"
+  done
+  echo -e "${LGRAY}${SEPARATOR}"
+  echo -e "Test Count${NC}: $TESTED"
+  echo -e "${GREEN}Passed${NC}:     $((${TESTED}-${FAILED}))"
+  echo -e "${RED}Failed${NC}:     $FAILED"
+  echo -e "${LGRAY}${SEPARATOR}${NC}"
+}

--- a/test/test-mp-launch-delete
+++ b/test/test-mp-launch-delete
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+#
+# Tests creation and deletion of Multipass instances with VM-utility
+# tools like mp-ssh, mp-launch, mp-route and mp-delete.
+#
+# Run this test from the root of the repository:
+# $ test/test-mp-launch-delete
 
 . test/test-calls
 

--- a/test/test-mp-launch-delete
+++ b/test/test-mp-launch-delete
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+. test/test-calls
+
+VM1='mp-made'
+VM2='mp-made-ssh'
+VM3='mpl-made'
+VM4='mpl-made-ip'
+VM4_IP=10.10.10.11
+
+make_vms() {
+
+  local errors=0
+
+  name="Launching the VM: $VM1 with the multipass"
+  if ! tstep "$name" multipass launch -n $VM1; then
+    errors=$((errors+1))
+  fi
+
+  name="Launching the VM: $VM2 with the multipass"
+  if ! tstep "${name}" multipass launch -n $VM2; then
+    errors=$((errors+1))
+  fi
+
+  name="Enabling ssh connection to the $VM2 with the mp-ssh"
+  if ! tcase "${name}" mp-ssh $VM2 -q; then
+    errors=$((errors+1))
+  fi
+
+  name="Launching the VM: $VM3 with the mp-launch"
+  if ! tcase "${name}" mp-launch -n $VM3 -q; then
+    errors=$((errors+1))
+  fi
+
+  name="Launching the VM: $VM4 with the mp-launch --ip $VM4_IP"
+  if ! tcase "${name}" mp-launch -n $VM4 -i $VM4_IP -q; then
+    errors=$((errors+1))
+  fi
+
+  return $errors
+
+}
+
+show_vms() {
+  tstep "multipass list" multipass list
+  tstep "VM IPs" cat ~/.vmu/vm_ips
+}
+
+name="Creating test-VMs"
+tset "${name}" make_vms
+
+show_vms
+
+name="Deleting test-VMs with the mp-delete without arguments"
+tcase "${name}" mp-delete $VM1 $VM2 $VM3 $VM4
+
+show_vms
+
+name="Purging the test-VMs with the mp-delete --purge"
+tcase "${name}" mp-delete $VM1 $VM2 $VM3 $VM4 -p
+
+show_vms
+
+name="Re-creating test-VMs"
+tset "${name}" make_vms
+
+show_vms
+
+name="Deleting test-VMs with the mp-delete --purge -v"
+tcase "${name}" mp-delete $VM1 $VM2 $VM3 $VM4 -pv
+
+show_vms
+
+tsummary

--- a/vmu-calls
+++ b/vmu-calls
@@ -1,9 +1,12 @@
-# Helper functions for setting environment for VM-utility tools
+# Helper functions and environment variables for VM-utility tools
+
+VMU_ENV=~/.vmu/environment
+VMU_IPS=~/.vmu/vm_ips
 
 #######################################
 # Notification written in stdout when environment is not set properly.
 #######################################
-config_error_note() {
+note_config_error() {
   echo "VMU_HOME is not set."
   echo
   echo "To configure the vm-utility tools, call:"
@@ -16,7 +19,7 @@ config_error_note() {
 #######################################
 # Notification written in stdout when tools are not set up properly.
 #######################################
-setup_error_note() {
+note_setup_error() {
   echo "Error in VM-utility configuration."
   echo
   echo "To make tools available from the /usr/local/bin, call the setup"
@@ -28,24 +31,138 @@ setup_error_note() {
 }
 
 #######################################
-# Sets environmnet for VM-utility tools.
+# Set environmnet for VM-utility tools.
 # Outputs:
 #   0 if environmnet set properly, non-zero on error.
 #######################################
 set_env() {
   if [ -z "$VMU_HOME" ]; then
-    if [ ! -r ~/.vmu/environment ]; then
+    if [ ! -r $VMU_ENV ]; then
       if ! vmu-config $(dirname $(realpath $BASH_SOURCE)); then
-         setup_error_note
-         config_error_note
+         note_setup_error
+         note_config_error
          return 1
       fi
     fi
-    if ! . ~/.vmu/environment; then
-      setup_error_note
-      config_error_note
+    if ! . $VMU_ENV; then
+      note_setup_error
+      note_config_error
       return 1
     fi
   fi
   return 0
+}
+
+#######################################
+# Update a <key>=<value> pair in a configuration file.
+# Arguments:
+#   Key
+#   Value
+#   Configuration file
+# Outputs
+#   0 if configuration file was updated, non-zero on error.
+#######################################
+set_config() {
+
+  # arguments
+  local key=$1
+  local value=$2
+  local file=$3
+
+  # create a configuration file if it does not exist yet
+  if [ ! -f $file ]; then
+    touch $file
+  fi
+
+  local line_nro=0
+  while read line; do
+    line_nro=$((line_nro+1))
+    # existing key found
+    if [ ${line%=*} == $key ]; then
+      # update value for the existing key
+      if ! sed -i "${line_nro}s/.*/${key}=${value}/" $file; then
+        return 1
+      fi
+      return 0
+    fi
+  done < $file
+
+  # add a new key
+  if ! echo $key=$value >> $file; then
+    return 1
+  fi
+  return 0
+
+}
+
+#######################################
+# Remove a line with a key from a configuration file.
+# Arguments:
+#   Key
+#   Configuration file
+# Outputs
+#   0 if key was removed, non-zero otherwise.
+#######################################
+unset_config() {
+
+  # arguments
+  local key=$1
+  local file=$2
+
+  local line_nro=0
+  while read line; do
+    line_nro=$((line_nro+1))
+    if [ ${line%=*} == $key ]; then
+      if ! sed -i "${line_nro}d" $file; then
+        return 1
+      fi
+      return 0
+    fi
+  done < $file
+  return 1
+
+}
+
+#######################################
+# Get a value for a given key from a configuration file.
+# Arguments:
+#   Key
+#   Configuration file
+# Outputs
+#   0 if key was removed, non-zero otherwise.
+#   Writes the value to stdout.
+#######################################
+get_config() {
+
+  # arguments
+  local key=$1
+  local file=$2
+
+  while read line; do
+    if [ ${line%=*} == $key ]; then
+      echo ${line#*=}
+      return 0
+    fi
+  done < $file
+  return 1
+}
+
+
+#######################################
+# Get all keys from a configuration file.
+# Arguments:
+#   Configuration file
+# Outputs
+#   0 if keys were found, non-zero otherwise.
+#   Writes list of keys to stdout using space as separator.
+#######################################
+get_keys() {
+  local file=$1
+  if [ -f $file ]; then
+    if ! echo $(cat $file | cut -d '=' -f 1); then
+      return 1
+    fi
+    return 0
+  fi
+  return 1
 }


### PR DESCRIPTION
New files:

  multipass/mp-delete
  - tool to delete Multipass instances made with or without the utility
  - deletes also routes created by the mp-route
  - removes any known hosts keys from the host to deleted VMs

  test/test-calls
  - gobal variables and functions to implement a simple test framework

  test/test-mp-launch-delete
  - tests for creating and deleting VMs (using the test-calls)

Modified:

  vmu-calls
  - add functions for managing simple configuration files
  - introduce ~/.vmu/vm_ips config file for storing IP addresses of VMs
  - cosmetic: names of functions in line with general convention

  multipass/mp-ssh
  - add the IP address of configured VM to the ~/.vmu/vm_ips config
 -  remove known hosts keys when IP address is re-configured 

  multipass/mp-route
  - determine the IP address of a VM using the ~/.vmu/vm_ips config

  multipass/README.md
  - documenting mp-delete  

  setup
  - add the mp-delete script to the installed scripts