### PR TITLE
test-vmu: Fix for setting a new test environment

### DIFF
--- a/test/test-vmu
+++ b/test/test-vmu
@@ -29,12 +29,13 @@ REMOTE=$(find_remote)
 set_test_env() {
 
   TEST_NAME=$(basename $BASH_SOURCE)
-  TEST_DIR=$(realpath "test.tmp/$TEST_NAME")
+  TEST_DIR=test.tmp/$TEST_NAME
 
   rm -frv $TEST_DIR
   ./setup $TEST_DIR
 
-  export PATH="$TEST_DIR:$PATH"
+  TEST_PATH=$(realpath $TEST_DIR)
+  export PATH="${TEST_PATH}:${PATH}"
   export VMU_HOME=$PWD
   . mp-calls
 }


### PR DESCRIPTION
Fixing show stopper when starting tests did not work without previous vmu-utility installation directory for testing.